### PR TITLE
Show tasks without a time assigned in the all-day section

### DIFF
--- a/src/calendars/DailyNoteCalendar.ts
+++ b/src/calendars/DailyNoteCalendar.ts
@@ -87,6 +87,7 @@ const getListsUnderHeading = (
     if (!headingPos) {
         return [];
     }
+
     return metadata.listItems?.filter(
         (l) =>
             headingPos.start.offset < l.position.start.offset &&
@@ -109,10 +110,16 @@ const getInlineEventFromLine = (
     globalAttrs: Partial<OFCEvent>
 ): OFCEvent | null => {
     const attrs = getInlineAttributes(text);
+    let extraAttrs: any = {};
 
-    // Shortcut validation if there are no inline attributes.
+    // if there are no inline attributes assume this is a task that isn't
+    // assigned to a time yet and show it in the all-day field so it can be
     if (Object.keys(attrs).length === 0) {
-        return null;
+        extraAttrs = {
+            type: "single",
+            allDay: true,
+            startTime: (globalAttrs as any).date,
+        };
     }
 
     return validateEvent({
@@ -120,6 +127,7 @@ const getInlineEventFromLine = (
         completed: checkboxTodo(text),
         ...globalAttrs,
         ...attrs,
+        ...extraAttrs,
     });
 };
 


### PR DESCRIPTION
This assigns a default startTime to daily note tasks without inline attributes. Which allows creating a list of tasks and then dragging them to an appropriate time.

Note that globalAttrs is cast as any because the inferred zod type is missing all the fields from the discriminated union (please let me know if this is expected / what the fix is).

Merging Existing PR into Fork
https://github.com/obsidian-community/obsidian-full-calendar/pull/531