### PR TITLE
When creating daily note, wait for it to be created before reading headings (fixes #555)

### DIFF
--- a/src/calendars/DailyNoteCalendar.ts
+++ b/src/calendars/DailyNoteCalendar.ts
@@ -303,8 +303,8 @@ export default class DailyNoteCalendar extends EditableCalendar {
         }
         const metadata = await this.app.waitForMetadata(file);
         await this.app.read(file);
+		await new Promise(resolve => setTimeout(resolve, 1000));
 
-		/* Removed because this was always returning undefined as of latest Obsidian.
         const headingInfo = metadata.headings?.find(
             (h) => h.heading == this.heading
         );
@@ -313,7 +313,7 @@ export default class DailyNoteCalendar extends EditableCalendar {
                 `Could not find heading ${this.heading} in daily note ${file.path}.`
             );
         }
-		*/
+
         let lineNumber = await this.app.rewrite(file, (contents) => {
             const { page, lineNumber } = addToHeading(contents, {
                 heading: headingInfo,

--- a/src/calendars/DailyNoteCalendar.ts
+++ b/src/calendars/DailyNoteCalendar.ts
@@ -303,7 +303,7 @@ export default class DailyNoteCalendar extends EditableCalendar {
         }
         const metadata = await this.app.waitForMetadata(file);
         await this.app.read(file);
-		await new Promise(resolve => setTimeout(resolve, 250));
+		await new Promise(resolve => setTimeout(resolve, 500));
 
         const headingInfo = metadata.headings?.find(
             (h) => h.heading == this.heading

--- a/src/calendars/DailyNoteCalendar.ts
+++ b/src/calendars/DailyNoteCalendar.ts
@@ -303,6 +303,7 @@ export default class DailyNoteCalendar extends EditableCalendar {
         }
         const metadata = await this.app.waitForMetadata(file);
         await this.app.read(file);
+		await new Promise(resolve => setTimeout(resolve, 250));
 
         const headingInfo = metadata.headings?.find(
             (h) => h.heading == this.heading

--- a/src/calendars/DailyNoteCalendar.ts
+++ b/src/calendars/DailyNoteCalendar.ts
@@ -303,8 +303,8 @@ export default class DailyNoteCalendar extends EditableCalendar {
         }
         const metadata = await this.app.waitForMetadata(file);
         await this.app.read(file);
-		await new Promise(resolve => setTimeout(resolve, 500));
 
+		/* Removed because this was always returning undefined as of latest Obsidian.
         const headingInfo = metadata.headings?.find(
             (h) => h.heading == this.heading
         );
@@ -313,6 +313,7 @@ export default class DailyNoteCalendar extends EditableCalendar {
                 `Could not find heading ${this.heading} in daily note ${file.path}.`
             );
         }
+		*/
         let lineNumber = await this.app.rewrite(file, (contents) => {
             const { page, lineNumber } = addToHeading(contents, {
                 heading: headingInfo,

--- a/src/calendars/DailyNoteCalendar.ts
+++ b/src/calendars/DailyNoteCalendar.ts
@@ -302,6 +302,7 @@ export default class DailyNoteCalendar extends EditableCalendar {
             file = (await createDailyNote(m)) as TFile;
         }
         const metadata = await this.app.waitForMetadata(file);
+        await this.app.read(file);
 
         const headingInfo = metadata.headings?.find(
             (h) => h.heading == this.heading

--- a/src/calendars/DailyNoteCalendar.ts
+++ b/src/calendars/DailyNoteCalendar.ts
@@ -301,9 +301,9 @@ export default class DailyNoteCalendar extends EditableCalendar {
         if (!file) {
             file = (await createDailyNote(m)) as TFile;
         }
+		await this.app.read(file);
+		await new Promise(resolve => setTimeout(resolve, 500));
         const metadata = await this.app.waitForMetadata(file);
-        await this.app.read(file);
-		await new Promise(resolve => setTimeout(resolve, 1000));
 
         const headingInfo = metadata.headings?.find(
             (h) => h.heading == this.heading


### PR DESCRIPTION
merging old pr into fork.

https://github.com/obsidian-community/obsidian-full-calendar/pull/556